### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ FastAPI native extension, easy and simple JWT auth
 ## Features
 * OpenAPI schema generation 
 * Native integration with FastAPI
-* Access/Refresh JTW
+* Access/Refresh JWT
 * JTI
 * Cookie setting
 


### PR DESCRIPTION
I think the abbreviation for Json Web Token is spelled wrong here.