### PR TITLE
Add compatibility for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with: { python-version: 3.9 }
+        with: { python-version: '3.10' }
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']  # ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7,<3.10
+python_requires = >=3.7
 install_requires =
-    fastapi >=0.50.0,<0.80.0
-    python-jose[cryptography] >=3.3.0,<4.0.0
+    fastapi >=0.50.0
+    python-jose[cryptography] >=3.3.0
 
 [options.package_data]
 fastapi-jwt = py.typed


### PR DESCRIPTION
Changes:

1.  Remove the version upper-limit for Python, fastapi, and python-jose
2. Add Python 3.10 to the Test workflow
    - testing against 3.10 is passing

Cheers!
Kyle