### PR TITLE
fix: Resolve deprecation warning by using explicit UTC timezone instead of `datetime.utcnow`

### DIFF
--- a/fastapi_jwt/jwt.py
+++ b/fastapi_jwt/jwt.py
@@ -15,6 +15,17 @@ except ImportError:  # pragma: nocover
     jwt = None  # type: ignore[assignment]
 
 
+def utcnow():
+    try:
+        from datetime import UTC
+    except ImportError:  # pragma: nocover
+        # UTC was added in python 3.12, as datetime.utcnow was
+        # marked for deprecation.
+        return datetime.utcnow()
+    else:
+        return datetime.now(UTC)
+
+
 __all__ = [
     "JwtAuthorizationCredentials",
     "JwtAccessBearer",
@@ -132,7 +143,7 @@ class JwtAuthBase(ABC):
         unique_identifier: str,
         token_type: str,
     ) -> Dict[str, Any]:
-        now = datetime.utcnow()
+        now = utcnow()
 
         return {
             "subject": subject.copy(),  # main subject


### PR DESCRIPTION
Starting from python 3.12.0, we started seeing some deprecation warning related to use of `datetime.datetime.utcnow`:

```
  /Users/.../lib/python3.12/site-packages/fastapi_jwt/jwt.py:135: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()
```

This PR should provide the same level of functionality without firing a deprecation warning, by implementing the suggested change.