### PR TITLE
Support standard JWT payload

### DIFF
--- a/fastapi_jwt/jwt.py
+++ b/fastapi_jwt/jwt.py
@@ -37,14 +37,9 @@ __all__ = [
 ]
 
 
-class JwtAuthorizationCredentials:
-    def __init__(self, subject: Dict[str, Any], jti: Optional[str] = None):
-        self.subject = subject
-        self.jti = jti
-
-    def __getitem__(self, item: str) -> Any:
-        return self.subject[item]
-
+class JwtAuthorizationCredentials(dict):
+    def __init__(self, payload: Dict[str, Any]):
+        super().__init__(payload)
 
 class JwtAuthBase(ABC):
     class JwtAccessCookie(APIKeyCookie):
@@ -293,7 +288,7 @@ class JwtAccess(JwtAuthBase):
 
         if payload:
             return JwtAuthorizationCredentials(
-                payload[self.subject_key], payload.get("jti", None)
+                payload
             )
         return None
 


### PR DESCRIPTION
I found 3 significant issues that directly prevented me from using this library for decoding a JWT token that was created by separate code:

1. Specifying "aud" as audience and "iss" as issuer to jose's decode function, as well as any other kwargs that jose supports. This can now be done with a decode_kwargs parameter.
2. Use of the standard "sub" instead of "subject" for subject. I made "sub" the default so this change could affect existing applications that already have tokens generated, but you can also specify subject_key="subject".
3. Instead of only returning subject and jti in the credentials payload available to the API code, return the whole payload so all data is available. I implemented this by having JwtAuthorizationCredentials inherit from dict and represent the payload directly.

After the above fixes, I was able to get my use case to work.

Example use:
`access_security = JwtAccessBearer(secret_key='your-secret-key'), auto_error=True, decode_kwargs={"audience": "My-Service", "issuer": "whoever made the key"}, subject_key="sub")`