### PR TITLE
update pip commnads

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ FastAPI native extension, easy and simple JWT auth
 ## Installation
 You can access package [fastapi-jwt in pypi](https://pypi.org/project/fastapi-jwt/)
 ```shell
-pip install fastapi-jwt[authlib]
+pip install 'fastapi-jwt[authlib]'
 # or
-pip install fastapi-jwt[python_jose]
+pip install 'fastapi-jwt[python_jose]'
 ```
 
 The fastapi-jwt will choose the backend automatically if library is installed with the following priority:


### PR DESCRIPTION
In this PR, I added single quotes around the installation commands in the "Installation" section of the documentation. This was necessary due to an issue I encountered on macOS: the command pip install fastapi-jwt[authlib] did not work and resulted in a zsh: no matches found error. Adding the quotes resolves this issue and allows the package to be installed correctly.







